### PR TITLE
番組表のポップアップをオプションで選択可能にする

### DIFF
--- a/EpgTimer/EpgTimer/Common/SettingClass.cs
+++ b/EpgTimer/EpgTimer/Common/SettingClass.cs
@@ -131,6 +131,7 @@ namespace EpgTimer
         private UInt32 serviceCustColor;
         private bool reserveRectBackground;
         private bool epgTitleIndent;
+        private bool epgPopup;
         private bool epgGradation;
         private bool epgGradationHeader;
         private double resColumnWidth0;
@@ -398,6 +399,11 @@ namespace EpgTimer
         {
             get { return epgTitleIndent; }
             set { epgTitleIndent = value; }
+        }
+        public bool EpgPopup
+        {
+            get { return epgPopup; }
+            set { epgPopup = value; }
         }
         public bool EpgGradation
         {
@@ -993,6 +999,7 @@ namespace EpgTimer
             serviceCustColor = 0xFFFFFFFF;
             reserveRectBackground = false;
             epgTitleIndent = true;
+            epgPopup = true;
             epgGradation = true;
             epgGradationHeader = true;
             resColumnHead = "";

--- a/EpgTimer/EpgTimer/EpgView/ProgramView.xaml.cs
+++ b/EpgTimer/EpgTimer/EpgView/ProgramView.xaml.cs
@@ -50,6 +50,8 @@ namespace EpgTimer.EpgView
 
         protected void PopupItem()
         {
+            if (Settings.Instance.EpgPopup == false) return;
+
             ProgramViewItem info = null;
 
             if (programTimeList != null)

--- a/EpgTimer/EpgTimer/Setting/SetEpgView.xaml
+++ b/EpgTimer/EpgTimer/Setting/SetEpgView.xaml
@@ -62,9 +62,10 @@
                             <Label Content="ドラッグスクロール倍率" Height="28" HorizontalAlignment="Left" Margin="327,36,0,0" Name="label10" VerticalAlignment="Top" />
                             <TextBox Height="24" HorizontalAlignment="Left" Margin="470,38,0,0" Name="textBox_dragScroll" VerticalAlignment="Top" Width="55" />
                             <CheckBox Content="番組内容表示位置を番組名表示位置にあわせる" Height="16" HorizontalAlignment="Left" Margin="357,70,0,0" Name="checkBox_title_indent" VerticalAlignment="Top" />
-                            <Label Content="グラデーション表示を行う" Height="28" HorizontalAlignment="Left" Margin="357,104,0,0" VerticalAlignment="Top" />
-                            <CheckBox Content="番組" Height="16" HorizontalAlignment="Left" Margin="510,109,0,0" Name="checkBox_gradation" VerticalAlignment="Top" />
-                            <CheckBox Content="サービス・時刻軸" Height="16" HorizontalAlignment="Left" Margin="570,109,0,0" Name="checkBox_gradationHeader" VerticalAlignment="Top" />
+                            <CheckBox Content="番組内容をポップアップ表示する" Height="16" HorizontalAlignment="Left" Margin="357,92,0,0" Name="checkBox_epg_popup" VerticalAlignment="Top" />
+                            <Label Content="グラデーション表示を行う" Height="28" HorizontalAlignment="Left" Margin="357,114,0,0" VerticalAlignment="Top" />
+                            <CheckBox Content="番組" Height="16" HorizontalAlignment="Left" Margin="510,119,0,0" Name="checkBox_gradation" VerticalAlignment="Top" />
+                            <CheckBox Content="サービス・時刻軸" Height="16" HorizontalAlignment="Left" Margin="570,119,0,0" Name="checkBox_gradationHeader" VerticalAlignment="Top" />
                             <CheckBox Content="シングルクリックで予約ダイアログを開く" Height="16" HorizontalAlignment="Left" Margin="11,148,0,0" Name="checkBox_singleOpen" VerticalAlignment="Top" />
                             <CheckBox Content="番組詳細タブを選択した状態で予約ダイアログを開く" Height="16" HorizontalAlignment="Left" Margin="357,148,0,0" Name="checkBox_openInfo" VerticalAlignment="Top" />
                             <CheckBox Content="自動" Height="16" HorizontalAlignment="Left" Margin="226,11,0,0" Name="checkBox_scrollAuto" VerticalAlignment="Top" />

--- a/EpgTimer/EpgTimer/Setting/SetEpgView.xaml.cs
+++ b/EpgTimer/EpgTimer/Setting/SetEpgView.xaml.cs
@@ -177,6 +177,7 @@ namespace EpgTimer.Setting
                 textBox_dragScroll.Text = Settings.Instance.DragScroll.ToString();
                 textBox_minimumHeight.Text = Settings.Instance.MinimumHeight.ToString();
                 checkBox_title_indent.IsChecked = Settings.Instance.EpgTitleIndent;
+                checkBox_epg_popup.IsChecked = Settings.Instance.EpgPopup;
                 checkBox_gradation.IsChecked = Settings.Instance.EpgGradation;
                 checkBox_gradationHeader.IsChecked = Settings.Instance.EpgGradationHeader;
 
@@ -298,6 +299,7 @@ namespace EpgTimer.Setting
                 {
                     Settings.Instance.EpgTitleIndent = false;
                 }
+                Settings.Instance.EpgPopup = (checkBox_epg_popup.IsChecked == true);
                 if (checkBox_gradation.IsChecked == true)
                 {
                     Settings.Instance.EpgGradation = true;


### PR DESCRIPTION
2chで議論になってますが、外してみると確かにそれはそれで良いような気もしたので。
もともとツールチップの代わりだったので、抑制オプションは必要だったのかもしれません。
よろしければ、お時間のあるときにでも。

![default](https://cloud.githubusercontent.com/assets/7290804/6079102/40c46e9a-ae44-11e4-90a0-df69d141fb73.png)
