### PR TITLE
予約ダイアログのフォルダ設定でキャンセルしても設定が変更されることがあるのを修正

### DIFF
--- a/EpgTimer/EpgTimer/UserCtrlView/RecSettingView.xaml.cs
+++ b/EpgTimer/EpgTimer/UserCtrlView/RecSettingView.xaml.cs
@@ -496,7 +496,7 @@ namespace EpgTimer
                 listView_recFolder.Items.Clear();
                 foreach (RecFileSetInfo info in recSetting.RecFolderList)
                 {
-                    listView_recFolder.Items.Add(info);
+                    listView_recFolder.Items.Add(GetCopyRecFileSetInfo(info));
                 }
 
                 if (recSetting.SuspendMode == 0)
@@ -563,7 +563,7 @@ namespace EpgTimer
                 listView_recFolder_1seg.Items.Clear();
                 foreach (RecFileSetInfo info in recSetting.PartialRecFolder)
                 {
-                    listView_recFolder_1seg.Items.Add(info);
+                    listView_recFolder_1seg.Items.Add(GetCopyRecFileSetInfo(info));
                 }
 
                 foreach (TunerSelectInfo info in comboBox_tuner.Items)
@@ -579,6 +579,16 @@ namespace EpgTimer
             {
                 MessageBox.Show(ex.Message + "\r\n" + ex.StackTrace);
             }
+        }
+
+        private RecFileSetInfo GetCopyRecFileSetInfo(RecFileSetInfo info)
+        {
+            var info_copy = new RecFileSetInfo();
+            info_copy.RecFileName = info.RecFileName;
+            info_copy.RecFolder = info.RecFolder;
+            info_copy.RecNamePlugIn = info.RecNamePlugIn;
+            info_copy.WritePlugIn = info.WritePlugIn;
+            return info_copy;
         }
 
         private void checkBox_suspendDef_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
わかりにくい不具合なのですが、結構嫌な問題かと思いましたので、ご報告させていただきます。

このコミットでとりあえず現象は起きなくなりますが、実際の修正は、あるいはxtne6fさんの方で別途作成していただいた方が良いかもしれません。(自分のフォークでの修正( 90b4af31fbc3aaddd5185f8471077804c5d983af )もこのコミットとは異なっていますので・・)

宜しくお願いします。
