### PR TITLE
録画プリセット追加時の挙動変更ほか

### DIFF
--- a/EpgTimer/EpgTimer/UserCtrlView/RecSettingView.xaml.cs
+++ b/EpgTimer/EpgTimer/UserCtrlView/RecSettingView.xaml.cs
@@ -649,7 +649,7 @@ namespace EpgTimer
             {
                 RecFileSetInfo setInfo = new RecFileSetInfo();
                 setting.GetSetting(ref setInfo);
-                foreach (RecFileSetInfo info in recSetting.RecFolderList)
+                foreach (RecFileSetInfoView info in listView_recFolder.Items)
                 {
                     if (String.Compare(setInfo.RecFolder, info.RecFolder, true) == 0 &&
                         String.Compare(setInfo.WritePlugIn, info.WritePlugIn, true) == 0 &&
@@ -826,7 +826,7 @@ namespace EpgTimer
             {
                 RecFileSetInfo setInfo = new RecFileSetInfo();
                 setting.GetSetting(ref setInfo);
-                foreach (RecFileSetInfo info in recSetting.PartialRecFolder)
+                foreach (RecFileSetInfoView info in listView_recFolder_1seg.Items)
                 {
                     if (String.Compare(setInfo.RecFolder, info.RecFolder, true) == 0 &&
                         String.Compare(setInfo.WritePlugIn, info.WritePlugIn, true) == 0 &&

--- a/EpgTimer/EpgTimer/UserCtrlView/RecSettingView.xaml.cs
+++ b/EpgTimer/EpgTimer/UserCtrlView/RecSettingView.xaml.cs
@@ -111,7 +111,7 @@ namespace EpgTimer
         public void AddPreset(String name)
         {
             RecSettingData newSet = new RecSettingData();
-            Settings.GetDefRecSetting(0, ref newSet);
+            GetRecSetting(ref newSet);
 
             RecPresetItem newInfo = new RecPresetItem();
             newInfo.DisplayName = name;


### PR DESCRIPTION
録画設定ダイアログ絡みで修正2点ご報告させていただきます。

・録画プリセット追加の際、現在の設定で追加するように変更
元の動きは、仕様としてはかなり操作者の期待を裏切っているように思えます。
(特に予約変更ダイアログから実行した場合とか)
どうでしょうか。

・録画予約ダイアログのフォルダ設定の挙動を一部修正
よほどレアな状況でない限り気になることはないかと思いますが、併せてprしておきます。

よろしくお願いします。
# とはいえ、今まで誰も気にしてないようですし、録画プリセット機能あまり使われてないんですかね。
