### PR TITLE
ShortInfoが抜けている番組でエラーが発生するのを修正

### DIFF
--- a/EpgTimer/EpgTimer/DefineClass/SearchItem.cs
+++ b/EpgTimer/EpgTimer/DefineClass/SearchItem.cs
@@ -275,6 +275,7 @@ namespace EpgTimer
             get
             {
                 if (this.EventInfo == null) { return null; }
+                if (this.EventInfo.ShortInfo == null) { return null; }
                 //
                 return this.EventInfo.ShortInfo.text_char.Replace("\r\n", " ");
             }


### PR DESCRIPTION
たまたまエラーになり気付いたので。
他と同様のチェックコードの追加です。
