### PR TITLE
カスタム番組表の設定でキャンセルしても設定が変更されることがあるのを修正

### DIFF
--- a/EpgTimer/EpgTimer/Setting/SetEpgView.xaml.cs
+++ b/EpgTimer/EpgTimer/Setting/SetEpgView.xaml.cs
@@ -134,7 +134,9 @@ namespace EpgTimer.Setting
                 }
                 foreach (CustomEpgTabInfo info in Settings.Instance.CustomEpgTabList)
                 {
-                    listBox_tab.Items.Add(info);
+                    var info_copy = new CustomEpgTabInfo();
+                    info.CopyTo(ref info_copy);
+                    listBox_tab.Items.Add(info_copy);
                 }
                 if (listBox_tab.Items.Count > 0)
                 {


### PR DESCRIPTION
更新お疲れ様です。

#8 や #13 と同様の参照バグです。
気付いたのでご報告いたします。

番組表の場合は割り切って子ウィンドウ側の確定でもいいのかもしれませんが、
その一方で番組表から設定画面を開いた場合は、一時的な変更しか出来ない仕様だったりしますよね。