### PR TITLE
EpgTimerにファイル以外のものをドロップしたとき異常終了するのを修正

### DIFF
--- a/EpgTimer/EpgTimer/MainWindow.xaml.cs
+++ b/EpgTimer/EpgTimer/MainWindow.xaml.cs
@@ -559,7 +559,7 @@ namespace EpgTimer
         private void Window_PreviewDrop(object sender, DragEventArgs e)
         {
             string[] filePath = e.Data.GetData(DataFormats.FileDrop, true) as string[];
-            SendAddReserveFromArgs(CommonManager.CreateSrvCtrl(), filePath);
+            if (filePath != null) SendAddReserveFromArgs(CommonManager.CreateSrvCtrl(), filePath);
         }
 
         private static void SendAddReserveFromArgs(CtrlCmdUtil cmd, IEnumerable<string> args)


### PR DESCRIPTION
選択した文字列とかドロップできてしまっていました。
よろしくお願いします。

<追記>
EpgTimer内部のテキストボックスなどからのドロップではクラッシュしますが、
外部からのドロップだとクラッシュまでは行かないようです。