### PR TITLE
番組説明テキストのイレギュラーなURIを無視するよう修正

### DIFF
--- a/EpgTimer/EpgTimer/Common/CommonManagerClass.cs
+++ b/EpgTimer/EpgTimer/Common/CommonManagerClass.cs
@@ -842,8 +842,15 @@ namespace EpgTimer
                     };
                     h.Foreground = SystemColors.HotTrackBrush;
                     h.Cursor = System.Windows.Input.Cursors.Hand;
-                    h.NavigateUri = new Uri(m.Value);
-                    para.Inlines.Add(h);
+                    try
+                    {
+                        h.NavigateUri = new Uri(m.Value);
+                        para.Inlines.Add(h);
+                    }
+                    catch
+                    {
+                        para.Inlines.Add(m.Value);
+                    }
                     searchFrom = m.Index + m.Length;
                 }
             }

--- a/EpgTimer/EpgTimer/Common/CommonManagerClass.cs
+++ b/EpgTimer/EpgTimer/Common/CommonManagerClass.cs
@@ -849,7 +849,7 @@ namespace EpgTimer
                     }
                     catch
                     {
-                        para.Inlines.Add(m.Value);
+                        para.Inlines.Add(text.Substring(m.Index, m.Length));
                     }
                     searchFrom = m.Index + m.Length;
                 }


### PR DESCRIPTION
テレビ朝日 4/11 23:55からの番組の説明にエラーとなる表現がありました。
マッチングで回避可能かもしれませんが、一応無視する処置を提案してみます。

番組説明よりエラー部分
`https://cluster.mu(アプリ「cluster」）`
