### PR TITLE
ユーザー名はOSの言語設定で変化するので、SIDを使用するように変更した

### DIFF
--- a/Common/PipeServer.cpp
+++ b/Common/PipeServer.cpp
@@ -6,6 +6,7 @@
 #include "CommonDef.h"
 #ifdef _WIN32
 #include <aclapi.h>
+#include <sddl.h>
 #else
 #include <poll.h>
 #include <sys/ioctl.h>
@@ -57,11 +58,15 @@ bool CPipeServer::StartServer(
 		wstring eventName = (L"Global\\" + pipeName).replace(7 + pipeName.find(L"Pipe"), 4, i == 0 ? L"Connect" : L"NoWaitConnect");
 		this->hEventConnects[i] = CreateEvent(NULL, FALSE, FALSE, eventName.c_str());
 		if( this->hEventConnects[i] && GetLastError() != ERROR_ALREADY_EXISTS ){
-			WCHAR trusteeName[] = L"NT AUTHORITY\\Authenticated Users";
+
+			//NT AUTHORITY\\Authenticated Users
+			//ユーザー名はOSの言語設定で変化するので、SIDを使用する
+			WCHAR trusteeName[] = L"S-1-5-11";
 			DWORD writeDac = 0;
+			insecureFlag = true;
 			if( insecureFlag ){
 				//現在はSYNCHRONIZEでよいが以前のクライアントはCreateEvent()で開いていたのでGENERIC_ALLが必要
-				if( GrantAccessToKernelObject(this->hEventConnects[i], trusteeName, GENERIC_ALL) ){
+				if( GrantAccessToKernelObjectWithSid(this->hEventConnects[i], trusteeName, GENERIC_ALL) ){
 					AddDebugLogFormat(L"Granted GENERIC_ALL on %ls to %ls", eventName.c_str(), trusteeName);
 					writeDac = WRITE_DAC;
 				}
@@ -73,7 +78,7 @@ bool CPipeServer::StartServer(
 			this->hPipes[i] = CreateNamedPipe(pipePath.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | writeDac, 0, 1, 8192, 8192, PIPE_TIMEOUT, NULL);
 			if( this->hPipes[i] != INVALID_HANDLE_VALUE ){
 				if( insecureFlag ){
-					if( writeDac && GrantAccessToKernelObject(this->hPipes[i], trusteeName, GENERIC_READ | GENERIC_WRITE) ){
+					if( writeDac && GrantAccessToKernelObjectWithSid(this->hPipes[i], trusteeName, GENERIC_READ | GENERIC_WRITE) ){
 						AddDebugLogFormat(L"Granted GENERIC_READ|GENERIC_WRITE on %ls to %ls", pipePath.c_str(), trusteeName);
 					}
 				}else if( writeDac && GrantServerAccessToKernelObject(this->hPipes[i], GENERIC_READ | GENERIC_WRITE) ){
@@ -180,6 +185,38 @@ BOOL CPipeServer::GrantAccessToKernelObject(HANDLE handle, WCHAR* trusteeName, D
 			LocalFree(pNewDacl);
 		}
 		LocalFree(pSecurityDesc);
+	}
+	return ret;
+}
+
+BOOL CPipeServer::GrantAccessToKernelObjectWithSid(HANDLE handle, WCHAR* trusteeName, DWORD permissions)
+{
+	BOOL ret = FALSE;
+	PACL pDacl;
+	PSECURITY_DESCRIPTOR pSecurityDesc;
+	if( GetSecurityInfo(handle, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, NULL, NULL, &pDacl, NULL, &pSecurityDesc) == ERROR_SUCCESS ){
+
+		PSID sid;
+		if( ConvertStringSidToSid( trusteeName, &sid ) ){
+			EXPLICIT_ACCESS explicitAccess;
+			memset( &explicitAccess, 0, sizeof( EXPLICIT_ACCESS ) );
+			explicitAccess.grfAccessPermissions = permissions;
+			explicitAccess.grfAccessMode = SET_ACCESS;
+			explicitAccess.grfInheritance = NO_INHERITANCE;
+			explicitAccess.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+			explicitAccess.Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+			explicitAccess.Trustee.ptstrName = (LPTSTR)sid;
+
+			PACL pNewDacl;
+			if( SetEntriesInAcl( 1, &explicitAccess, pDacl, &pNewDacl ) == ERROR_SUCCESS ){
+				if( SetSecurityInfo( handle, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, NULL, NULL, pNewDacl, NULL ) == ERROR_SUCCESS ){
+					ret = TRUE;
+				}
+				LocalFree( pNewDacl );
+			}
+			LocalFree( sid );
+		}
+		LocalFree( pSecurityDesc );
 	}
 	return ret;
 }

--- a/Common/PipeServer.cpp
+++ b/Common/PipeServer.cpp
@@ -63,10 +63,10 @@ bool CPipeServer::StartServer(
 			//ユーザー名はOSの言語設定で変化するので、SIDを使用する
 			WCHAR trusteeName[] = L"S-1-5-11";
 			DWORD writeDac = 0;
-			insecureFlag = true;
+
 			if( insecureFlag ){
 				//現在はSYNCHRONIZEでよいが以前のクライアントはCreateEvent()で開いていたのでGENERIC_ALLが必要
-				if( GrantAccessToKernelObjectWithSid(this->hEventConnects[i], trusteeName, GENERIC_ALL) ){
+				if( GrantAccessToKernelObject(this->hEventConnects[i], trusteeName, true, GENERIC_ALL) ){
 					AddDebugLogFormat(L"Granted GENERIC_ALL on %ls to %ls", eventName.c_str(), trusteeName);
 					writeDac = WRITE_DAC;
 				}
@@ -78,7 +78,7 @@ bool CPipeServer::StartServer(
 			this->hPipes[i] = CreateNamedPipe(pipePath.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | writeDac, 0, 1, 8192, 8192, PIPE_TIMEOUT, NULL);
 			if( this->hPipes[i] != INVALID_HANDLE_VALUE ){
 				if( insecureFlag ){
-					if( writeDac && GrantAccessToKernelObjectWithSid(this->hPipes[i], trusteeName, GENERIC_READ | GENERIC_WRITE) ){
+					if( writeDac && GrantAccessToKernelObject(this->hPipes[i], trusteeName, true, GENERIC_READ | GENERIC_WRITE) ){
 						AddDebugLogFormat(L"Granted GENERIC_READ|GENERIC_WRITE on %ls to %ls", pipePath.c_str(), trusteeName);
 					}
 				}else if( writeDac && GrantServerAccessToKernelObject(this->hPipes[i], GENERIC_READ | GENERIC_WRITE) ){
@@ -166,17 +166,32 @@ bool CPipeServer::StopServer(bool checkOnlyFlag)
 BOOL CPipeServer::GrantServerAccessToKernelObject(HANDLE handle, DWORD permissions)
 {
 	WCHAR trusteeName[] = L"NT Service\\" SERVICE_NAME;
-	return GrantAccessToKernelObject(handle, trusteeName, permissions);
+	return GrantAccessToKernelObject(handle, trusteeName, false, permissions);
 }
 
-BOOL CPipeServer::GrantAccessToKernelObject(HANDLE handle, WCHAR* trusteeName, DWORD permissions)
+BOOL CPipeServer::GrantAccessToKernelObject(HANDLE handle, WCHAR* trusteeName, bool trusteeIsSid, DWORD permissions)
 {
 	BOOL ret = FALSE;
 	PACL pDacl;
 	PSECURITY_DESCRIPTOR pSecurityDesc;
 	if( GetSecurityInfo(handle, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, NULL, NULL, &pDacl, NULL, &pSecurityDesc) == ERROR_SUCCESS ){
+		PSID sid= nullptr;
 		EXPLICIT_ACCESS explicitAccess;
-		BuildExplicitAccessWithName(&explicitAccess, trusteeName, permissions, GRANT_ACCESS, 0);
+		if( trusteeIsSid ){
+			if( ConvertStringSidToSid( trusteeName, &sid ) ){
+				memset( &explicitAccess, 0, sizeof( EXPLICIT_ACCESS ) );
+				explicitAccess.grfAccessPermissions = permissions;
+				explicitAccess.grfAccessMode = SET_ACCESS;
+				explicitAccess.grfInheritance = NO_INHERITANCE;
+				explicitAccess.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+				explicitAccess.Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+				explicitAccess.Trustee.ptstrName = (LPTSTR)sid;
+			}
+		}
+		else{
+			BuildExplicitAccessWithName( &explicitAccess, trusteeName, permissions, GRANT_ACCESS, 0 );
+		}
+
 		PACL pNewDacl;
 		if( SetEntriesInAcl(1, &explicitAccess, pDacl, &pNewDacl) == ERROR_SUCCESS ){
 			if( SetSecurityInfo(handle, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, NULL, NULL, pNewDacl, NULL) == ERROR_SUCCESS ){
@@ -184,36 +199,7 @@ BOOL CPipeServer::GrantAccessToKernelObject(HANDLE handle, WCHAR* trusteeName, D
 			}
 			LocalFree(pNewDacl);
 		}
-		LocalFree(pSecurityDesc);
-	}
-	return ret;
-}
-
-BOOL CPipeServer::GrantAccessToKernelObjectWithSid(HANDLE handle, WCHAR* trusteeName, DWORD permissions)
-{
-	BOOL ret = FALSE;
-	PACL pDacl;
-	PSECURITY_DESCRIPTOR pSecurityDesc;
-	if( GetSecurityInfo(handle, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, NULL, NULL, &pDacl, NULL, &pSecurityDesc) == ERROR_SUCCESS ){
-
-		PSID sid;
-		if( ConvertStringSidToSid( trusteeName, &sid ) ){
-			EXPLICIT_ACCESS explicitAccess;
-			memset( &explicitAccess, 0, sizeof( EXPLICIT_ACCESS ) );
-			explicitAccess.grfAccessPermissions = permissions;
-			explicitAccess.grfAccessMode = SET_ACCESS;
-			explicitAccess.grfInheritance = NO_INHERITANCE;
-			explicitAccess.Trustee.TrusteeForm = TRUSTEE_IS_SID;
-			explicitAccess.Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
-			explicitAccess.Trustee.ptstrName = (LPTSTR)sid;
-
-			PACL pNewDacl;
-			if( SetEntriesInAcl( 1, &explicitAccess, pDacl, &pNewDacl ) == ERROR_SUCCESS ){
-				if( SetSecurityInfo( handle, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, NULL, NULL, pNewDacl, NULL ) == ERROR_SUCCESS ){
-					ret = TRUE;
-				}
-				LocalFree( pNewDacl );
-			}
+		if( sid != nullptr ){
 			LocalFree( sid );
 		}
 		LocalFree( pSecurityDesc );

--- a/Common/PipeServer.h
+++ b/Common/PipeServer.h
@@ -35,6 +35,7 @@ protected:
 	HANDLE hPipes[2];
 
 	static BOOL GrantAccessToKernelObject(HANDLE handle, WCHAR* trusteeName, DWORD permissions);
+	static BOOL GrantAccessToKernelObjectWithSid(HANDLE handle, WCHAR* trusteeName, DWORD permissions);
 #else
 	int srvSock;
 	string sockPath;

--- a/Common/PipeServer.h
+++ b/Common/PipeServer.h
@@ -34,8 +34,7 @@ protected:
 	HANDLE hEventConnects[2];
 	HANDLE hPipes[2];
 
-	static BOOL GrantAccessToKernelObject(HANDLE handle, WCHAR* trusteeName, DWORD permissions);
-	static BOOL GrantAccessToKernelObjectWithSid(HANDLE handle, WCHAR* trusteeName, DWORD permissions);
+	static BOOL GrantAccessToKernelObject(HANDLE handle, WCHAR* trusteeName, bool trusteeIsSid, DWORD permissions);
 #else
 	int srvSock;
 	string sockPath;


### PR DESCRIPTION
NT AUTHORITY\\Authenticated Usersというユーザー名、これがOSの言語設定によって変化することがあって、言語設定によっては失敗してしまいます。
英語と日本語はAuthenticated Usersですが、スペイン語だとUsuarios Autenticadosになります。
SIDで指定すると不変なので失敗しません。

日本語、英語の動作にももちろん支障はありません。
最小限の変更にしました。
いかがでしょうか?
